### PR TITLE
Improve UTM gallery scraping to list all VMs

### DIFF
--- a/utm-gallery-get.py
+++ b/utm-gallery-get.py
@@ -15,7 +15,7 @@ Usage examples:
   ./utm-gallery-get.py --name LAB-VICTIM --copies 2
 """
 
-import sys, os, time, glob, shutil, zipfile, plistlib, random
+import sys, os, time, glob, shutil, zipfile, plistlib, random, json
 from urllib.parse import urljoin, urlparse
 import argparse
 import requests
@@ -55,19 +55,101 @@ def fetch(url):
     r.raise_for_status()
     return r.text
 
+def gather_zip_links(node):
+    links = []
+    if isinstance(node, str):
+        if node.lower().endswith(".zip"):
+            links.append(node)
+    elif isinstance(node, dict):
+        for v in node.values():
+            links.extend(gather_zip_links(v))
+    elif isinstance(node, (list, tuple, set)):
+        for item in node:
+            links.extend(gather_zip_links(item))
+    return links
+
+
+def extract_from_next_data(index_html):
+    """Parse Next.js hydration data when available to enumerate gallery items."""
+    soup = BeautifulSoup(index_html, "html.parser")
+    script = soup.find("script", id="__NEXT_DATA__")
+    if not script or not script.string:
+        return []
+
+    try:
+        data = json.loads(script.string)
+    except json.JSONDecodeError:
+        return []
+
+    items = {}
+
+    def visit(node):
+        if isinstance(node, dict):
+            slug = node.get("path") or node.get("url") or node.get("slug")
+            zips = gather_zip_links(node.get("downloads")) if "downloads" in node else []
+            if not zips:
+                for key in ("downloadUrl", "downloadURL", "directLink", "file", "files"):
+                    if key in node:
+                        zips.extend(gather_zip_links(node[key]))
+
+            if slug and zips:
+                if isinstance(slug, str):
+                    page = slug if slug.startswith("http") else urljoin(GALLERY_BASE, slug.lstrip("/"))
+                else:
+                    page = None
+                if page and page.startswith(GALLERY_BASE):
+                    title = node.get("title") or node.get("name") or os.path.basename(urlparse(page).path)
+                    norm_page = page.rstrip("/")
+                    existing = items.get(norm_page)
+                    if existing:
+                        existing["zips"].extend(zips)
+                    else:
+                        items[norm_page] = {"title": title, "page": page, "zips": list(zips)}
+
+            for value in node.values():
+                visit(value)
+        elif isinstance(node, (list, tuple, set)):
+            for value in node:
+                visit(value)
+
+    visit(data)
+
+    # Deduplicate and normalize zip URLs
+    normalized = []
+    for item in items.values():
+        unique_zips = []
+        seen = set()
+        for link in item["zips"]:
+            resolved = urljoin(item["page"], link) if not urlparse(link).scheme else link
+            if resolved not in seen:
+                seen.add(resolved)
+                unique_zips.append(resolved)
+        item["zips"] = unique_zips
+        normalized.append(item)
+    return normalized
+
+
 def find_vm_pages(index_html):
+    """Return gallery entries discovered on the landing page."""
+    # Prefer structured data embedded in the page when available.
+    items = extract_from_next_data(index_html)
+    if items:
+        return items
+
+    # Fallback to scraping anchor tags when the structured data is unavailable.
     soup = BeautifulSoup(index_html, "html.parser")
     links = []
     for a in soup.find_all("a", href=True):
         href = a["href"]
-        if "/gallery/" in href or href.strip("/").endswith((".html","/")):
+        if "/gallery/" in href or href.strip("/").endswith((".html", "/")):
             full = urljoin(GALLERY_BASE, href)
             if full.startswith(GALLERY_BASE):
                 links.append(full)
     seen, out = set(), []
-    for l in links:
-        if l not in seen:
-            seen.add(l); out.append(l)
+    for link in links:
+        if link not in seen:
+            seen.add(link)
+            out.append({"title": link, "page": link, "zips": []})
     return out
 
 def find_zip_for_page(page_html, page_url):
@@ -118,33 +200,76 @@ def main():
 
     print("Fetching UTM gallery index…")
     idx_html = fetch(GALLERY_BASE)
-    pages = find_vm_pages(idx_html)
+    discovered = find_vm_pages(idx_html)
 
     items = []
-    for p in pages:
-        try:
-            html = fetch(p)
-        except Exception:
+    for entry in discovered:
+        if isinstance(entry, dict):
+            page_url = entry.get("page") or entry.get("url")
+            title_hint = entry.get("title")
+            zips = list(entry.get("zips", []))
+        else:
+            page_url = entry
+            title_hint = None
+            zips = []
+
+        if not page_url:
             continue
-        soup = BeautifulSoup(html, "html.parser")
-        title = soup.find(["h1","h2"])
-        title_text = title.get_text().strip() if title else p
-        zips = find_zip_for_page(html, p)
-        if zips:
-            items.append({"title": title_text, "page": p, "zips": zips})
+
+        if not urlparse(page_url).scheme:
+            page_url = urljoin(GALLERY_BASE, page_url.lstrip("/"))
+
+        page_html = None
+        if not zips:
+            try:
+                page_html = fetch(page_url)
+            except Exception:
+                continue
+            zips = find_zip_for_page(page_html, page_url)
+
+        if not zips:
+            continue
+
+        title_text = title_hint
+        if title_text is None:
+            if page_html is None:
+                try:
+                    page_html = fetch(page_url)
+                except Exception:
+                    page_html = ""
+            soup = BeautifulSoup(page_html, "html.parser") if page_html else None
+            title = None
+            if soup:
+                title = soup.find(["h1", "h2"])
+            title_text = title.get_text().strip() if title else page_url
+
+        items.append({"title": title_text, "page": page_url, "zips": zips})
 
     if not items:
         print("No downloadable VMs found.")
         sys.exit(1)
 
+    # Deduplicate by page URL in case multiple sources returned the same entry.
+    deduped = []
+    seen_pages = set()
+    for item in items:
+        page_key = item["page"].rstrip("/")
+        if page_key not in seen_pages:
+            seen_pages.add(page_key)
+            deduped.append(item)
+
+    if not deduped:
+        print("No downloadable VMs found.")
+        sys.exit(1)
+
     print("\nAvailable VMs:")
-    for i, it in enumerate(items, start=1):
+    for i, it in enumerate(deduped, start=1):
         print(f"{i:2d}. {it['title']}")
         for z in it['zips']:
             print(f"     → {z}")
     sel = input("\nEnter number to download (or q): ").strip().lower()
     if sel == 'q': sys.exit(0)
-    choice = items[int(sel)-1]
+    choice = deduped[int(sel)-1]
     zipurl = choice['zips'][0]
 
     os.makedirs(args.downloads, exist_ok=True)


### PR DESCRIPTION
## Summary
- parse the gallery landing page's Next.js data to enumerate all VM entries
- fall back to anchor scraping when structured data is unavailable and deduplicate results
- avoid redundant page fetches while still retrieving titles and download URLs

## Testing
- python -m compileall utm-gallery-get.py

------
https://chatgpt.com/codex/tasks/task_e_68dd7a2db848832cb08644d924c5cb79